### PR TITLE
Add cancel session functionality to GPS sharing feature

### DIFF
--- a/src/core/network/APIEndpoint.ts
+++ b/src/core/network/APIEndpoint.ts
@@ -190,6 +190,7 @@ export const ApiEndpoints = {
     getSession: (sessionId: string) => `/GPSSharing/session/${sessionId}`,
     getSessions: "/GPSSharing/sessions",
     getSessionsByRenterId: (renterId: string) => `/GPSSharing/sessions/renter/${renterId}`,
+    cancel: (sessionId: string) => `/GPSSharing/session/${sessionId}/cancel`,
   },
 
   // Additional Fees endpoints

--- a/src/data/datasources/implementations/remote/gpsSharing/GpsSharingRemoteDataSourceImpl.ts
+++ b/src/data/datasources/implementations/remote/gpsSharing/GpsSharingRemoteDataSourceImpl.ts
@@ -83,7 +83,7 @@ export class GpsSharingRemoteDataSourceImpl
 
   async cancel(sessionId: string): Promise<ApiResponse<any>> {
     try {
-      const response = await this.axiosClient.put<ApiResponse<any>>(
+      const response = await this.axiosClient.delete<ApiResponse<any>>(
         ApiEndpoints.gpsSharing.cancel(sessionId)
       );
       return response.data;

--- a/src/data/datasources/implementations/remote/gpsSharing/GpsSharingRemoteDataSourceImpl.ts
+++ b/src/data/datasources/implementations/remote/gpsSharing/GpsSharingRemoteDataSourceImpl.ts
@@ -80,4 +80,16 @@ export class GpsSharingRemoteDataSourceImpl
       };
     }
   }
+
+  async cancel(sessionId: string): Promise<ApiResponse<any>> {
+    try {
+      const response = await this.axiosClient.put<ApiResponse<any>>(
+        ApiEndpoints.gpsSharing.cancel(sessionId)
+      );
+      return response.data;
+    } catch (error: any) {
+      console.error("Error canceling session:", error);
+      throw error;
+    }
+  }
 }

--- a/src/data/datasources/interfaces/remote/gpsSharing/GpsSharingRemoteDataSource.ts
+++ b/src/data/datasources/interfaces/remote/gpsSharing/GpsSharingRemoteDataSource.ts
@@ -11,5 +11,6 @@ export interface GpsSharingRemoteDataSource {
     getSession(sessionId: string): Promise<ApiResponse<SessionDetailResponse>>;
     getSessions(): Promise<ApiResponse<any[]>>;
     getSessionsByRenterId(renterId: string): Promise<ApiResponse<any[]>>;
+    cancel(sessionId: string): Promise<ApiResponse<any>>;
 }
 

--- a/src/data/repositories/gpsSharing/GpsSharingRepositoryImpl.ts
+++ b/src/data/repositories/gpsSharing/GpsSharingRepositoryImpl.ts
@@ -28,4 +28,8 @@ export class GpsSharingRepositoryImpl implements GpsSharingRepository {
     async getSessionsByRenterId(renterId: string): Promise<ApiResponse<any[]>> {
         return await this.remoteDataSource.getSessionsByRenterId(renterId);
     }
+
+    async cancel(sessionId: string): Promise<ApiResponse<any>> {
+        return await this.remoteDataSource.cancel(sessionId);
+    }
 }

--- a/src/domain/repositories/gpsSharing/GpsSharingRepository.ts
+++ b/src/domain/repositories/gpsSharing/GpsSharingRepository.ts
@@ -10,4 +10,5 @@ export interface GpsSharingRepository {
     getSession(sessionId: string): Promise<ApiResponse<SessionDetailResponse>>;
     getSessions(): Promise<ApiResponse<any[]>>;
     getSessionsByRenterId(renterId: string): Promise<ApiResponse<any[]>>;
+    cancel(sessionId: string): Promise<ApiResponse<any>>;
 }

--- a/src/domain/usecases/gpsSharing/CancelGpsSharingSessionUseCase.ts
+++ b/src/domain/usecases/gpsSharing/CancelGpsSharingSessionUseCase.ts
@@ -1,0 +1,15 @@
+import { GpsSharingRepository } from "../../repositories/gpsSharing/GpsSharingRepository";
+import { ApiResponse } from "../../../core/network/APIResponse";
+
+export class CancelGpsSharingSessionUseCase {
+    private repository: GpsSharingRepository;
+
+    constructor(repository: GpsSharingRepository) {
+        this.repository = repository;
+    }
+
+    async execute(sessionId: string): Promise<ApiResponse<any>> {
+        return this.repository.cancel(sessionId);
+    }
+}
+

--- a/src/presentation/features/gpsSharing/ui/screens/GpsSharingSessionListScreen.tsx
+++ b/src/presentation/features/gpsSharing/ui/screens/GpsSharingSessionListScreen.tsx
@@ -22,6 +22,7 @@ import { ScreenHeader } from "../../../../common/components/organisms/ScreenHead
 import { colors } from "../../../../common/theme/colors";
 import Toast from "react-native-toast-message";
 import { GetSessionByRenterIdUseCase } from "../../../../../domain/usecases/gpsSharing/GetSessionByRenterIdUseCase";
+import { CancelGpsSharingSessionUseCase } from "../../../../../domain/usecases/gpsSharing/CancelGpsSharingSessionUseCase";
 import { Booking } from "../../../../../domain/entities/booking/Booking";
 
 export const GpsSharingSessionListScreen: React.FC = () => {
@@ -37,19 +38,24 @@ export const GpsSharingSessionListScreen: React.FC = () => {
   const [selectedBookingId, setSelectedBookingId] = useState<string | null>(
     null
   );
+  const [cancelingSessionId, setCancelingSessionId] = useState<string | null>(
+    null
+  );
 
-  useEffect(() => {
-    const init = async () => {
-      try {
-        const booking = await fetchCurrentBooking();
-        await fetchSessions(booking?.renterId);
-      } catch (error) {
-        console.error("Error initializing GPS sharing sessions:", error);
-      }
-    };
+  useFocusEffect(
+    useCallback(() => {
+      const init = async () => {
+        try {
+          const booking = await fetchCurrentBooking();
+          await fetchSessions(booking?.renterId);
+        } catch (error) {
+          console.error("Error initializing GPS sharing sessions:", error);
+        }
+      };
 
-    init();
-  }, []);
+      init();
+    }, [])
+  );
 
   const fetchCurrentBooking = async (): Promise<Booking | null> => {
     try {
@@ -147,8 +153,7 @@ export const GpsSharingSessionListScreen: React.FC = () => {
       const getSessionByRenterIdUseCase = new GetSessionByRenterIdUseCase(
         sl.get("GpsSharingRepository")
       );
-      const response =
-        await getSessionByRenterIdUseCase.execute(renterId);
+      const response = await getSessionByRenterIdUseCase.execute(renterId);
 
       if (response.success && response.data) {
         setSessions(response.data);
@@ -255,6 +260,60 @@ export const GpsSharingSessionListScreen: React.FC = () => {
         guestRenterName: item.guestRenterName,
       });
     }
+  };
+
+  const handleCancelSession = async (sessionId: string) => {
+    Alert.alert(
+      "Hủy chia sẻ GPS",
+      "Bạn có chắc chắn muốn hủy session chia sẻ GPS này?",
+      [
+        {
+          text: "Không",
+          style: "cancel",
+        },
+        {
+          text: "Hủy session",
+          style: "destructive",
+          onPress: async () => {
+            try {
+              setCancelingSessionId(sessionId);
+              const cancelUseCase = new CancelGpsSharingSessionUseCase(
+                sl.get("GpsSharingRepository")
+              );
+              const response = await cancelUseCase.execute(sessionId);
+
+              if (response.success) {
+                Toast.show({
+                  type: "success",
+                  text1: "Thành công",
+                  text2: "Đã hủy session chia sẻ GPS",
+                });
+                // Refresh sessions list
+                const booking = await fetchCurrentBooking();
+                await fetchSessions(booking?.renterId);
+              } else {
+                Toast.show({
+                  type: "error",
+                  text1: "Lỗi",
+                  text2: response.message || "Không thể hủy session",
+                });
+              }
+            } catch (error: any) {
+              console.error("Error canceling session:", error);
+              Toast.show({
+                type: "error",
+                text1: "Lỗi",
+                text2:
+                  error.response?.data?.message ||
+                  "Đã xảy ra lỗi khi hủy session",
+              });
+            } finally {
+              setCancelingSessionId(null);
+            }
+          },
+        },
+      ]
+    );
   };
 
   const renderSessionItem = ({ item }: { item: any }) => {
@@ -412,6 +471,25 @@ export const GpsSharingSessionListScreen: React.FC = () => {
               </Text>
             </View>
           )}
+
+          {/* Cancel Button */}
+          <TouchableOpacity
+            style={styles.cancelButton}
+            onPress={() => handleCancelSession(item.sessionId)}
+            disabled={cancelingSessionId === item.sessionId}
+            activeOpacity={0.8}
+          >
+            <View style={styles.cancelButtonContent}>
+              {cancelingSessionId === item.sessionId ? (
+                <ActivityIndicator size="small" color="#FF6B6B" />
+              ) : (
+                <>
+                  <AntDesign name="close-circle" size={16} color="#FF6B6B" />
+                  <Text style={styles.cancelButtonText}>Hủy chia sẻ</Text>
+                </>
+              )}
+            </View>
+          </TouchableOpacity>
         </View>
       </TouchableOpacity>
     );
@@ -671,6 +749,28 @@ const styles = StyleSheet.create({
     fontSize: 11,
     color: "#81C784",
     fontWeight: "600",
+  },
+  cancelButton: {
+    marginTop: 12,
+    borderRadius: 14,
+    overflow: "hidden",
+    borderWidth: 1.5,
+    borderColor: "rgba(255,107,107,0.3)",
+    backgroundColor: "rgba(255,107,107,0.1)",
+  },
+  cancelButtonContent: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+  },
+  cancelButtonText: {
+    fontSize: 14,
+    fontWeight: "700",
+    color: "#FF6B6B",
+    letterSpacing: 0.3,
   },
   cardHeaderGradient: {
     backgroundColor: "rgba(125,179,255,0.05)",

--- a/src/presentation/features/gpsSharing/ui/screens/GpsSharingSessionListScreen.tsx
+++ b/src/presentation/features/gpsSharing/ui/screens/GpsSharingSessionListScreen.tsx
@@ -473,23 +473,25 @@ export const GpsSharingSessionListScreen: React.FC = () => {
           )}
 
           {/* Cancel Button */}
-          <TouchableOpacity
-            style={styles.cancelButton}
-            onPress={() => handleCancelSession(item.sessionId)}
-            disabled={cancelingSessionId === item.sessionId}
-            activeOpacity={0.8}
-          >
-            <View style={styles.cancelButtonContent}>
-              {cancelingSessionId === item.sessionId ? (
-                <ActivityIndicator size="small" color="#FF6B6B" />
-              ) : (
-                <>
-                  <AntDesign name="close-circle" size={16} color="#FF6B6B" />
-                  <Text style={styles.cancelButtonText}>Hủy chia sẻ</Text>
-                </>
-              )}
-            </View>
-          </TouchableOpacity>
+          {isActive && (
+            <TouchableOpacity
+              style={styles.cancelButton}
+              onPress={() => handleCancelSession(item.sessionId)}
+              disabled={cancelingSessionId === item.sessionId}
+              activeOpacity={0.8}
+            >
+              <View style={styles.cancelButtonContent}>
+                {cancelingSessionId === item.sessionId ? (
+                  <ActivityIndicator size="small" color="#FF6B6B" />
+                ) : (
+                  <>
+                    <AntDesign name="close-circle" size={16} color="#FF6B6B" />
+                    <Text style={styles.cancelButtonText}>Hủy chia sẻ</Text>
+                  </>
+                )}
+              </View>
+            </TouchableOpacity>
+          )}
         </View>
       </TouchableOpacity>
     );

--- a/src/presentation/features/gpsSharing/ui/screens/GpsSharingTrackingScreen.tsx
+++ b/src/presentation/features/gpsSharing/ui/screens/GpsSharingTrackingScreen.tsx
@@ -6,6 +6,7 @@ import {
   TouchableOpacity,
   ActivityIndicator,
   Image,
+  Alert,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useNavigation, useRoute } from "@react-navigation/native";
@@ -17,9 +18,11 @@ import BottomSheet, { BottomSheetView } from "@gorhom/bottom-sheet";
 import sl from "../../../../../core/di/InjectionContainer";
 import { SessionDetailResponse } from "../../../../../data/models/gpsSharing/SessionDetailResponse";
 import { GetGpsSharingSessionDetailUseCase } from "../../../../../domain/usecases/gpsSharing/GetGpsSharingSessionDetailUseCase";
+import { CancelGpsSharingSessionUseCase } from "../../../../../domain/usecases/gpsSharing/CancelGpsSharingSessionUseCase";
 import CustomMapViewDirections from "../organisms/CustomMapViewDirections";
 import { useAppSelector } from "../../../authentication/store/hooks";
 import { RootState } from "../../../authentication/store";
+import Toast from "react-native-toast-message";
 
 type DeviceLocation = {
   lat: number;
@@ -51,6 +54,7 @@ export const GpsSharingTrackingScreen: React.FC = () => {
   const [mqttError, setMqttError] = useState<string | null>(null);
   const [sessionDetail, setSessionDetail] =
     useState<SessionDetailResponse | null>(null);
+  const [canceling, setCanceling] = useState(false);
   const mapRef = useRef<MapView | null>(null);
   const ownerClientRef = useRef<MqttClient | null>(null);
   const guestClientRef = useRef<MqttClient | null>(null);
@@ -432,6 +436,68 @@ export const GpsSharingTrackingScreen: React.FC = () => {
     );
   }, [mapRef, sessionDetail, user, ownerLocation, guestLocation]);
 
+  const handleCancelSession = useCallback(() => {
+    if (!sessionId) return;
+
+    Alert.alert(
+      "Hủy chia sẻ GPS",
+      "Bạn có chắc chắn muốn hủy session chia sẻ GPS này?",
+      [
+        {
+          text: "Không",
+          style: "cancel",
+        },
+        {
+          text: "Hủy session",
+          style: "destructive",
+          onPress: async () => {
+            try {
+              setCanceling(true);
+              const cancelUseCase = new CancelGpsSharingSessionUseCase(
+                sl.get("GpsSharingRepository")
+              );
+              const response = await cancelUseCase.execute(sessionId);
+
+              if (response.success) {
+                Toast.show({
+                  type: "success",
+                  text1: "Thành công",
+                  text2: "Đã hủy session chia sẻ GPS",
+                });
+                // Disconnect MQTT clients
+                if (ownerClientRef.current) {
+                  ownerClientRef.current.end(true);
+                }
+                if (guestClientRef.current) {
+                  guestClientRef.current.end(true);
+                }
+                // Navigate back
+                navigation.goBack();
+              } else {
+                Toast.show({
+                  type: "error",
+                  text1: "Lỗi",
+                  text2: response.message || "Không thể hủy session",
+                });
+              }
+            } catch (error: any) {
+              console.error("Error canceling session:", error);
+              Toast.show({
+                type: "error",
+                text1: "Lỗi",
+                text2:
+                  error.response?.data?.message ||
+                  "Đã xảy ra lỗi khi hủy session",
+              });
+            } finally {
+              setCanceling(false);
+            }
+          },
+        },
+      ]
+    );
+  }, [sessionId, navigation]);
+
   return (
     <View style={styles.container}>
       {/* Full Screen Map */}
@@ -695,6 +761,29 @@ export const GpsSharingTrackingScreen: React.FC = () => {
               <Text style={styles.errorText}>{mqttError}</Text>
             </View>
           )}
+
+          {/* Cancel Session Button */}
+          <TouchableOpacity
+            style={styles.cancelSessionButton}
+            onPress={handleCancelSession}
+            disabled={canceling}
+            activeOpacity={0.8}
+          >
+            <View style={styles.cancelSessionButtonContent}>
+              {canceling ? (
+                <ActivityIndicator size="small" color="#FF6B6B" />
+              ) : (
+                <>
+                  <View style={styles.cancelSessionIconContainer}>
+                    <AntDesign name="close-circle" size={18} color="#FF6B6B" />
+                  </View>
+                  <Text style={styles.cancelSessionButtonText}>
+                    Hủy chia sẻ GPS
+                  </Text>
+                </>
+              )}
+            </View>
+          </TouchableOpacity>
         </BottomSheetView>
       </BottomSheet>
     </View>
@@ -1011,6 +1100,36 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: "#FF8A80",
     fontWeight: "500",
+  },
+  cancelSessionButton: {
+    marginTop: 20,
+    borderRadius: 16,
+    overflow: "hidden",
+    borderWidth: 1.5,
+    borderColor: "rgba(255,107,107,0.4)",
+    backgroundColor: "rgba(255,107,107,0.12)",
+  },
+  cancelSessionButtonContent: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 10,
+    paddingVertical: 16,
+    paddingHorizontal: 20,
+  },
+  cancelSessionIconContainer: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: "rgba(255,107,107,0.2)",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  cancelSessionButtonText: {
+    fontSize: 15,
+    fontWeight: "700",
+    color: "#FF6B6B",
+    letterSpacing: 0.5,
   },
 });
 


### PR DESCRIPTION
- Introduced a new API endpoint for canceling GPS sharing sessions.
- Implemented cancel method in GpsSharingRemoteDataSource and GpsSharingRepository.
- Added UI components and logic for canceling sessions in GpsSharingSessionListScreen and GpsSharingTrackingScreen.
- Integrated toast notifications for success and error messages during cancellation.